### PR TITLE
Adding support for tls.config

### DIFF
--- a/client.go
+++ b/client.go
@@ -124,7 +124,7 @@ type WrappedClient struct {
 }
 
 func Client(config *Config) *WrappedClient {
-	tlsConfig := &tls.Config{}
+	tlsConfig := config.TlsConfig
 
 	var resolver *net.Resolver = nil
 	if config.InTestMode {

--- a/client_test.go
+++ b/client_test.go
@@ -48,7 +48,7 @@ func TestTLSConfig(t *testing.T) {
 	cfg := GetConfigBuilder().SetTlsConfig(tls_config).Build()
 	client := Client(cfg)
 
-	_, err := client.Get("https://boli-blog.pl/")
+	_, err := client.Get("https://expired.badssl.com/")
 	if err != nil {
 		t.Errorf("Failed to make insecure connection %v", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package safeurl
 
 import (
+	"crypto/tls"
 	"fmt"
 	"testing"
 )
@@ -38,6 +39,20 @@ func TestBlockedIP(t *testing.T) {
 			t.Errorf("client returned incorrect error: %v", err)
 		}
 	}
+}
+
+func TestTLSConfig(t *testing.T) {
+	tls_config := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	cfg := GetConfigBuilder().SetTlsConfig(tls_config).Build()
+	client := Client(cfg)
+
+	_, err := client.Get("https://boli-blog.pl/")
+	if err != nil {
+		t.Errorf("Failed to make insecure connection %v", err)
+	}
+
 }
 
 func TestBlockCIDRRange(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package safeurl
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -27,6 +28,8 @@ type configBuilder struct {
 	isDebugLoggingEnabled bool
 
 	inTestMode bool
+
+	tlsConfig *tls.Config
 }
 
 type Config struct {
@@ -52,6 +55,8 @@ type Config struct {
 
 	IsDebugLoggingEnabled bool
 	InTestMode            bool
+
+	TlsConfig *tls.Config
 }
 
 func GetConfigBuilder() *configBuilder {
@@ -68,6 +73,7 @@ func GetConfigBuilder() *configBuilder {
 
 		isDebugLoggingEnabled: false,
 		inTestMode:            false,
+		tlsConfig:             nil,
 	}
 }
 
@@ -141,6 +147,11 @@ func (cb *configBuilder) EnableTestMode(enable bool) *configBuilder {
 	return cb
 }
 
+func (cb *configBuilder) SetTlsConfig(tlsConfig *tls.Config) *configBuilder {
+	cb.tlsConfig = tlsConfig
+	return cb
+}
+
 func (cb *configBuilder) Build() *Config {
 	wc := &Config{
 		Timeout:       cb.timeout,
@@ -152,6 +163,7 @@ func (cb *configBuilder) Build() *Config {
 
 		IsDebugLoggingEnabled: cb.isDebugLoggingEnabled,
 		InTestMode:            cb.inTestMode,
+		TlsConfig:             cb.tlsConfig,
 	}
 
 	if cb.allowedSchemes == nil {


### PR DESCRIPTION
Initial version was using empty tls.Config - my changes simply adds it into available option while building a client.