### PR TITLE
Add SetTransport to allow overriding the transport

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,17 +14,23 @@ import (
 )
 
 func buildHttpClient(wc *WrappedClient) *http.Client {
+	transport := &http.Transport{}
+	if wc.transport != nil {
+		transport = wc.transport.Clone()
+	}
+	if wc.tlsConfig != nil {
+		transport.TLSClientConfig = wc.tlsConfig
+	}
+	transport.DialContext = (&net.Dialer{
+		Resolver: wc.resolver,
+		Control:  buildRunFunc(wc),
+	}).DialContext
+
 	client := &http.Client{
 		Timeout:       wc.config.Timeout,
 		CheckRedirect: wc.config.CheckRedirect,
 		Jar:           wc.config.Jar,
-		Transport: &http.Transport{
-			TLSClientConfig: wc.tlsConfig,
-			DialContext: (&net.Dialer{
-				Resolver: wc.resolver,
-				Control:  buildRunFunc(wc),
-			}).DialContext,
-		},
+		Transport:     transport,
 	}
 
 	return client
@@ -120,6 +126,7 @@ type WrappedClient struct {
 	Client *http.Client
 
 	config    *Config
+	transport *http.Transport
 	tlsConfig *tls.Config
 	resolver  *net.Resolver
 
@@ -129,6 +136,7 @@ type WrappedClient struct {
 
 func Client(config *Config) *WrappedClient {
 	tlsConfig := config.TlsConfig
+	transport := config.Transport
 
 	var resolver *net.Resolver = nil
 	if config.InTestMode {
@@ -143,6 +151,7 @@ func Client(config *Config) *WrappedClient {
 
 	wc := &WrappedClient{
 		config:    config,
+		transport: transport,
 		tlsConfig: tlsConfig,
 		resolver:  resolver,
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package safeurl
 import (
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"testing"
 )
 
@@ -46,6 +47,43 @@ func TestTLSConfig(t *testing.T) {
 		InsecureSkipVerify: true,
 	}
 	cfg := GetConfigBuilder().SetTlsConfig(tls_config).Build()
+	client := Client(cfg)
+
+	_, err := client.Get("https://expired.badssl.com/")
+	if err != nil {
+		t.Errorf("Failed to make insecure connection %v", err)
+	}
+
+}
+
+func TestTransport(t *testing.T) {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	cfg := GetConfigBuilder().SetTransport(transport).Build()
+	client := Client(cfg)
+
+	_, err := client.Get("https://expired.badssl.com/")
+	if err != nil {
+		t.Errorf("Failed to make insecure connection %v", err)
+	}
+
+}
+
+func TestTransportAndTLSConfig(t *testing.T) {
+	cfg := GetConfigBuilder().
+		SetTransport(&http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: false,
+			},
+		}).
+		SetTlsConfig(&tls.Config{
+			InsecureSkipVerify: true,
+		}).
+		Build()
+
 	client := Client(cfg)
 
 	_, err := client.Get("https://expired.badssl.com/")

--- a/config.go
+++ b/config.go
@@ -30,6 +30,7 @@ type configBuilder struct {
 	inTestMode bool
 
 	tlsConfig *tls.Config
+	transport *http.Transport
 }
 
 type Config struct {
@@ -57,6 +58,7 @@ type Config struct {
 	InTestMode            bool
 
 	TlsConfig *tls.Config
+	Transport *http.Transport
 }
 
 func GetConfigBuilder() *configBuilder {
@@ -74,6 +76,7 @@ func GetConfigBuilder() *configBuilder {
 		isDebugLoggingEnabled: false,
 		inTestMode:            false,
 		tlsConfig:             nil,
+		transport:             nil,
 	}
 }
 
@@ -152,6 +155,15 @@ func (cb *configBuilder) SetTlsConfig(tlsConfig *tls.Config) *configBuilder {
 	return cb
 }
 
+// SetTransport provides an http.Transport to the underlying client.
+// The transport's DialContext will be overriden by safeurl.
+// If both SetTransport and SetTLSConfig are called, then the TLSConfig will be
+// set on the transport as part of constructing the client.
+func (cb *configBuilder) SetTransport(transport *http.Transport) *configBuilder {
+	cb.transport = transport
+	return cb
+}
+
 func (cb *configBuilder) Build() *Config {
 	wc := &Config{
 		Timeout:       cb.timeout,
@@ -164,6 +176,7 @@ func (cb *configBuilder) Build() *Config {
 		IsDebugLoggingEnabled: cb.isDebugLoggingEnabled,
 		InTestMode:            cb.inTestMode,
 		TlsConfig:             cb.tlsConfig,
+		Transport:             cb.transport,
 	}
 
 	if cb.allowedSchemes == nil {

--- a/config.go
+++ b/config.go
@@ -155,10 +155,10 @@ func (cb *configBuilder) SetTlsConfig(tlsConfig *tls.Config) *configBuilder {
 	return cb
 }
 
-// SetTransport provides an http.Transport to the underlying client.
-// The transport's DialContext will be overriden by safeurl.
+// SetTransport provides an `http.Transport` to the underlying client.
+// The transport's DialContext will be overridden by safeurl.
 // If both SetTransport and SetTLSConfig are called, then the TLSConfig will be
-// set on the transport as part of constructing the client.
+// set on the transport instance as part of constructing the client.
 func (cb *configBuilder) SetTransport(transport *http.Transport) *configBuilder {
 	cb.transport = transport
 	return cb


### PR DESCRIPTION
* Extend the Config to support overriding the transport. This can be useful if you want fine-grained control over settings such as MaxIdleConnsPerHost or DisableKeepAlives.

(Note: I've tried running the unit tests locally and they seem to be failing because some of the hardcoded IPs are timing out)