### PR TITLE
fix: improve error handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -54,7 +54,11 @@ func buildRunFunc(wc *WrappedClient) func(network, address string, c syscall.Raw
 			return &IPv6BlockedError{ip: address}
 		}
 
-		host, port, _ := net.SplitHostPort(address)
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			wc.log(fmt.Sprintf("invalid address format: %v", err))
+			return err
+		}
 
 		if !isPortAllowed(port, wc.config.AllowedPorts) {
 			wc.log(fmt.Sprintf("disallowed port: %v", port))
@@ -63,7 +67,8 @@ func buildRunFunc(wc *WrappedClient) func(network, address string, c syscall.Raw
 
 		ip := net.ParseIP(host)
 		if ip == nil {
-			panic(fmt.Sprintf("invalid ip: %v", host))
+			wc.log(fmt.Sprintf("invalid ip: %v", host))
+			return &InvalidHostError{host: host}
 		}
 
 		if isIPAllowed(ip, wc.config.AllowedIPs, wc.config.AllowedIPsCIDR) {

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package safeurl
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -554,5 +555,47 @@ func TestConfigTransportWithCustomDialPanics(t *testing.T) {
 
 			_ = Client(cfg)
 		})
+	}
+}
+
+func TestBuildRunFunc_invalidAddressFormatReturnsError(t *testing.T) {
+	wc := &WrappedClient{config: GetConfigBuilder().Build()}
+	run := buildRunFunc(wc)
+
+	cases := []struct {
+		name    string
+		address string
+	}{
+		{name: "missing port", address: "127.0.0.1"},
+		{name: "missing closing bracket", address: "[::1"},
+		{name: "hostname without port", address: "host"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run("tcp4", tc.address, nil)
+			if err == nil {
+				t.Fatal("expected error for invalid address format")
+			}
+
+			var addrErr *net.AddrError
+			if !errors.As(err, &addrErr) {
+				t.Fatalf("expected net.AddrError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestIPv4MappedIPv6WithZoneReturnsInvalidHostError(t *testing.T) {
+	cfg := GetConfigBuilder().Build()
+	client := Client(cfg)
+
+	_, err := client.Get("http://[::ffff:127.0.0.1%25any]")
+	if err == nil {
+		t.Fatal("expected error for IPv4-mapped IPv6 with zone identifier")
+	}
+	err = unwrap(err)
+	if _, ok := err.(*InvalidHostError); !ok {
+		t.Fatalf("expected InvalidHostError, got %T: %v", err, err)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -558,7 +558,7 @@ func TestConfigTransportWithCustomDialPanics(t *testing.T) {
 	}
 }
 
-func TestBuildRunFunc_invalidAddressFormatReturnsError(t *testing.T) {
+func TestInvalidAddressFormatReturnsError(t *testing.T) {
 	wc := &WrappedClient{config: GetConfigBuilder().Build()}
 	run := buildRunFunc(wc)
 


### PR DESCRIPTION
### Description

This pr addresses two improvements on error handling:
- return an error whenever `net.SplitHostPort(address)` fails, currently the error is ignored
- returning an error whenever `net.ParseIP(host)` returns nil, instead of panic